### PR TITLE
Allow to commit using the `Last-Fossil-Event-Number`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ curl -N --http2 -H "Accept: text/event-stream" http://localhost:8080/consumer/{n
 ```
 
 When the consumer is done with one (or multiple if you want to batch), commit its offset by sending 
-the latest known event number to the `/consumer/{name}/commit` endpoint:
+the latest known event identifier to the `/consumer/{name}/commit` endpoint:
 ```
 curl -X PUT -H 'Last-Event-Id: 123' http://localhost:8080/consumer/{name}/commit
 ```
+
+**Note:** You can also commit with the `Last-Fossil-Event-Number` header if you want to use the event number rather
+than their identifiers. This would actually be faster than using `Last-Event-Id` which is exposed for SSE compatibility.
 
 ### Delete or replace an event
 

--- a/events/events.go
+++ b/events/events.go
@@ -15,8 +15,8 @@ var toReplaceExistingEventExtensionName = "fossiltoreplaceexistingevent"
 var expectedSequenceNumberExtensionName = "fossilexpectedsequencenumber"
 
 type Matcher struct {
-	UriTemplate string
-	LastEventId int
+	UriTemplate     string
+	LastEventNumber int
 }
 
 func GetStreamFromEvent(event cloudevents.Event) string {
@@ -112,5 +112,5 @@ func EventMatches(event cloudevents.Event, matcher Matcher) bool {
 		return false
 	}
 
-	return GetEventNumber(event) > matcher.LastEventId
+	return GetEventNumber(event) > matcher.LastEventNumber
 }

--- a/postgres/store.go
+++ b/postgres/store.go
@@ -137,7 +137,7 @@ func (s *Storage) MatchingStream(ctx context.Context, matcher events.Matcher) ch
 
 	go func() {
 		streamAsRegex := "^" + strings.ReplaceAll(matcher.UriTemplate, "*", "[^\\/]*") + "$"
-		rows, err := s.conn.QueryEx(ctx, "select number, stream, sequence_number_in_stream, event from events where number > $1 and stream ~ $2 order by number asc", nil, matcher.LastEventId, streamAsRegex)
+		rows, err := s.conn.QueryEx(ctx, "select number, stream, sequence_number_in_stream, event from events where number > $1 and stream ~ $2 order by number asc", nil, matcher.LastEventNumber, streamAsRegex)
 		if err != nil {
 			fmt.Println("error went loading historical events", err)
 			close(channel)
@@ -168,7 +168,7 @@ func (s *Storage) MatchingStream(ctx context.Context, matcher events.Matcher) ch
 	return channel
 }
 
-func (s *Storage) Get(ctx context.Context, id string) (*cloudevents.Event, error) {
+func (s *Storage) Find(ctx context.Context, id string) (*cloudevents.Event, error) {
 	row := s.conn.QueryRowEx(ctx, "select number, stream, sequence_number_in_stream, event from events where id = $1", nil, id)
 
 	return rowToEvent(row)

--- a/postgres/store_test.go
+++ b/postgres/store_test.go
@@ -93,7 +93,7 @@ func TestStorage(t *testing.T) {
 			return
 		}
 
-		event, err := storage.Get(context.Background(), id)
+		event, err := storage.Find(context.Background(), id)
 		if err != nil {
 			t.Error(err)
 			return

--- a/store/errors.go
+++ b/store/errors.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+type EventNotFound struct{}
+
+func (e *EventNotFound) Error() string {
+	return "event with such identifier is not found."
+}
+
 type DuplicateEventError struct{}
 
 func (e *DuplicateEventError) Error() string {

--- a/store/http.go
+++ b/store/http.go
@@ -48,10 +48,10 @@ func NewFossilServer(
 		router.Use(jwtauth.Authenticator)
 	}
 
-	sseRouter := NewSSERouter(factory)
+	sseRouter := NewSSERouter(factory, store)
 	sseRouter.Mount(router)
 	NewCollectorRouter(collector, NewConsumerWaiter(factory.Broadcaster)).Mount(router)
-	NewConsumerGroup(sseRouter, store, loader, lock).Mount(router)
+	NewNamedConsumers(sseRouter, store, loader, lock).Mount(router)
 	NewConsumerWaiterRouter(collector).Mount(router)
 
 	router.Get("/about", func(writer http.ResponseWriter, request *http.Request) {

--- a/store/in_memory.go
+++ b/store/in_memory.go
@@ -32,12 +32,23 @@ func NewInMemoryStorage() *InMemoryStorage {
 	}
 }
 
+func (s *InMemoryStorage) Find(ctx context.Context, identifier string) (*cloudevents.Event, error) {
+	for _, e := range s.Events {
+		if e.ID() == identifier {
+			return &e, nil
+		}
+	}
+
+	return nil, &EventNotFound{}
+}
+
 func (s *InMemoryStorage) Store(ctx context.Context, stream string, event *cloudevents.Event) error {
 	err := s.addOrReplace(*event)
 	if err != nil {
 		return err
 	}
 
+	events.SetStream(event, stream)
 	events.SetEventNumber(event, len(s.Events))
 	events.SetSequenceNumberInStream(event, s.countEventsInStream(stream))
 

--- a/store/named_consumers_test.go
+++ b/store/named_consumers_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/sroze/fossil/concurrency"
+	"github.com/sroze/fossil/events"
+	testing2 "github.com/sroze/fossil/testing"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNamedConsumers(t *testing.T) {
+
+	storage := NewInMemoryStorage()
+	collector := NewCollector(
+		storage,
+		NewInMemoryPublisher(),
+	)
+
+	server := NewFossilServer(
+		collector,
+		NewEventStreamFactory(storage),
+		storage,
+		storage,
+		concurrency.NewInMemoryLock(),
+		"",
+	)
+
+	t.Run("Commits with the last known event number", func(t *testing.T) {
+		t.Run("with a valid event number", func(t *testing.T) {
+			consumerName := uuid.New().String()
+
+			request, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/consumer/%s/commit", consumerName), nil)
+			request.Header.Set("Last-Fossil-Event-Number", "12345")
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			ExpectResponseCode(t, response, 200)
+
+			if storage.countEventsInStream(fmt.Sprintf("fossil/consumer/%s/commit-offsets", consumerName)) != 1 {
+				t.Error("Expect one event but found none.")
+			}
+		})
+
+		t.Run("needs to be an integer", func(t *testing.T) {
+			consumerName := "testing"
+
+			request, _ := http.NewRequest(http.MethodPut, "/consumer/"+consumerName+"/commit", nil)
+			request.Header.Set("Last-Fossil-Event-Number", uuid.New().String())
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			ExpectResponseCode(t, response, 400)
+		})
+	})
+
+	t.Run("Commits with the last known event identifier", func(t *testing.T) {
+		t.Run("returns an error if the event does not exist", func(t *testing.T) {
+			consumerName := "testing"
+
+			request, _ := http.NewRequest(http.MethodPut, "/consumer/"+consumerName+"/commit", nil)
+			request.Header.Set("Last-Event-Id", uuid.New().String())
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			ExpectResponseCode(t, response, 404)
+		})
+
+		t.Run("uses the event's number to commit", func(t *testing.T) {
+			consumerName := uuid.New().String()
+			event := testing2.NewEvent(
+				uuid.New().String(),
+				"some/stream",
+				12,
+				1,
+			)
+
+			err := storage.Store(context.Background(), "some/stream", &event)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			request, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/consumer/%s/commit", consumerName), nil)
+			request.Header.Set("Last-Event-Id", event.ID())
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			ExpectResponseCode(t, response, 200)
+
+			committedEvent := <-storage.MatchingStream(context.Background(), events.Matcher{
+				UriTemplate: fmt.Sprintf("fossil/consumer/%s/commit-offsets", consumerName),
+			})
+
+			offset, err := getCommittedOffsetFromEvent(&committedEvent)
+			if err != nil {
+				t.Error(err)
+			} else if offset != events.GetEventNumber(event) {
+				t.Errorf("Expected event numbered %d but got %d", events.GetEventNumber(event), offset)
+			}
+		})
+	})
+}

--- a/store/publisher.go
+++ b/store/publisher.go
@@ -16,6 +16,7 @@ type Collector interface {
 
 type EventStore interface {
 	Store(ctx context.Context, stream string, event *cloudevents.Event) error
+	Find(ctx context.Context, id string) (*cloudevents.Event, error)
 }
 
 type EventLoader interface {

--- a/store/sse_test.go
+++ b/store/sse_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"bufio"
 	"context"
+	"github.com/google/uuid"
 	"github.com/sroze/fossil/concurrency"
+	"github.com/sroze/fossil/events"
 	fossiltesting "github.com/sroze/fossil/testing"
 	"net/http"
 	"net/http/httptest"
@@ -61,11 +63,13 @@ func TestSimpleEventStreaming(t *testing.T) {
 }
 
 func TestMatcherFromRequest(t *testing.T) {
+	storage := NewInMemoryStorage()
+
 	t.Run("it gets the template from query parameters", func(t *testing.T) {
 		request, _ := http.NewRequest(http.MethodGet, "/stream?matcher=foo", nil)
 		request.Header.Add("Accept", "text/event-stream")
 
-		matcher, err := matcherFromRequest(request)
+		matcher, err := matcherFromRequest(storage, request)
 		if err != nil {
 			t.Error(err)
 			return
@@ -76,19 +80,45 @@ func TestMatcherFromRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("last event id from headers", func(t *testing.T) {
+	t.Run("last event number from headers", func(t *testing.T) {
 		request, _ := http.NewRequest(http.MethodGet, "/stream?matcher=foo", nil)
 		request.Header.Add("Accept", "text/event-stream")
-		request.Header.Add("Last-Event-Id", "12")
+		request.Header.Add("Last-Fossil-Event-Number", "12")
 
-		matcher, err := matcherFromRequest(request)
+		matcher, err := matcherFromRequest(storage, request)
 		if err != nil {
 			t.Error(err)
 			return
 		}
 
-		if matcher.LastEventId != 12 {
-			t.Errorf("expected last event id to be 12, found %d instead", matcher.LastEventId)
+		if matcher.LastEventNumber != 12 {
+			t.Errorf("expected last event number to be 12, found %d instead", matcher.LastEventNumber)
+		}
+	})
+
+	t.Run("gets the last event number from the event id", func(t *testing.T) {
+		event := fossiltesting.NewEvent(uuid.New().String(), "some/stream", 0, 0)
+		err := storage.Store(context.Background(), "some/stream", &event)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		// Fake the event number
+		events.SetEventNumber(&event, 10)
+
+		request, _ := http.NewRequest(http.MethodGet, "/stream?matcher=foo", nil)
+		request.Header.Add("Accept", "text/event-stream")
+		request.Header.Add("Last-Event-Id", event.ID())
+
+		matcher, err := matcherFromRequest(storage, request)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if matcher.LastEventNumber != 10 {
+			t.Errorf("expected last event number to be 10, found %d instead", matcher.LastEventNumber)
 		}
 	})
 }


### PR DESCRIPTION
It is more performant with `Last-Fossil-Event-Number`. This actually fixes an issue where the `Last-Event-Id` was expected to be the event number. `Last-Event-Id` is just an SSE compatibility layer.