### PR TITLE
Use URI templates rather than the custom `*` matcher from Kafka

### DIFF
--- a/doc/concepts.md
+++ b/doc/concepts.md
@@ -12,12 +12,7 @@ This is an event, as defined by the [CloudEvents spec](https://github.com/cloude
 One stream is one instance of a specific stream pattern. 
 For example: `visits/0d11536e-a33b-4ee9-b14f-29f6764d24cd`.
 
-## Stream pattern
+## Stream template
 
 This is an abstraction allowing the event store to create the stream from an event.
-For example: `visits/{visit_id}`
-
-## Stream matcher
-
-Used when listening for messages. 
-For example: `visits/*`
+For example: `visits/{id}`

--- a/load-testing/Consumer.scala
+++ b/load-testing/Consumer.scala
@@ -8,7 +8,7 @@ import java.net.URLEncoder
 object Consumer {
   val listenEventsFor2Minutes = scenario("Listen for 2 minutes")
     .exec(
-      sse("StreamEvents").connect("/stream?matcher=" + URLEncoder.encode(Config.StreamPrefix + "/*"))
+      sse("StreamEvents").connect("/sse?stream=" + URLEncoder.encode(Config.StreamPrefix + "/{id}"))
     )
     .pause(120)
     .exec(sse("Close").close())

--- a/postgres/matcher.go
+++ b/postgres/matcher.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"fmt"
+	"github.com/sroze/fossil/events"
+	"github.com/yosida95/uritemplate"
+	"strings"
+)
+
+func uriTemplateAsPostgresRegex(uriTemplate string) string {
+	streamAsRegex := "^" + uriTemplate + "$"
+
+	template := uritemplate.MustNew(uriTemplate)
+	for _, varName := range template.Varnames() {
+		streamAsRegex = strings.ReplaceAll(streamAsRegex, "{"+varName+"}", "[^\\/]*")
+	}
+
+	return streamAsRegex
+}
+
+func buildSelectQuery(matcher events.Matcher) (string, []interface{}) {
+	var args []interface{}
+	args = append(args, matcher.LastEventNumber)
+
+	var streamMatchersAsSql []string
+	for index, uriTemplate := range matcher.UriTemplates {
+		streamMatchersAsSql = append(streamMatchersAsSql, fmt.Sprintf("stream ~ $%d", index+2))
+		args = append(args, uriTemplateAsPostgresRegex(uriTemplate))
+	}
+
+	streamsFilters := ""
+	if len(streamMatchersAsSql) > 0 {
+		streamsFilters = "and (" + strings.Join(streamMatchersAsSql, " or ") + ")"
+	}
+
+	return "select number, stream, sequence_number_in_stream, event from events where number > $1 " + streamsFilters + " order by number asc", args
+}

--- a/postgres/matcher_test.go
+++ b/postgres/matcher_test.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"github.com/sroze/fossil/events"
+	"testing"
+)
+
+func expectBuiltSelectQuery(t *testing.T, matcher events.Matcher, expectedSql string, expectedArgs []interface{}) {
+	sql, args := buildSelectQuery(matcher)
+
+	if sql != expectedSql {
+		t.Errorf("expected SQL is '%s' but got '%s'", expectedSql, sql)
+	}
+
+	if len(args) != len(expectedArgs) {
+		t.Errorf("expected %d args, got %d", len(expectedArgs), len(args))
+	}
+
+	for index, expectedValue := range expectedArgs {
+		if args[index] != expectedValue {
+			t.Errorf("expected value '%s', got '%s'", expectedValue, args[index])
+		}
+	}
+}
+
+func TestBuildSqlQuery(t *testing.T) {
+	t.Run("no stream templates, no last event", func(t *testing.T) {
+		expectBuiltSelectQuery(
+			t,
+			events.Matcher{
+				UriTemplates:    []string{},
+				LastEventNumber: 0,
+			},
+			"select number, stream, sequence_number_in_stream, event from events where number > $1  order by number asc",
+			[]interface{}{
+				0,
+			},
+		)
+	})
+
+	t.Run("no stream template, with last event", func(t *testing.T) {
+		expectBuiltSelectQuery(
+			t,
+			events.Matcher{
+				UriTemplates:    []string{},
+				LastEventNumber: 10,
+			},
+			"select number, stream, sequence_number_in_stream, event from events where number > $1  order by number asc",
+			[]interface{}{
+				10,
+			},
+		)
+	})
+
+	t.Run("one stream template and no last event", func(t *testing.T) {
+		expectBuiltSelectQuery(
+			t,
+			events.Matcher{
+				UriTemplates:    []string{"foo/bar"},
+				LastEventNumber: 0,
+			},
+			"select number, stream, sequence_number_in_stream, event from events where number > $1 and (stream ~ $2) order by number asc",
+			[]interface{}{
+				0,
+				"^foo/bar$",
+			},
+		)
+	})
+
+	t.Run("three stream templates and a last event", func(t *testing.T) {
+		expectBuiltSelectQuery(
+			t,
+			events.Matcher{
+				UriTemplates:    []string{"foo/bar", "visits/{id}", "care-recipients/{cr_id}/something-else"},
+				LastEventNumber: 10,
+			},
+			"select number, stream, sequence_number_in_stream, event from events where number > $1 and (stream ~ $2 or stream ~ $3 or stream ~ $4) order by number asc",
+			[]interface{}{
+				10,
+				"^foo/bar$",
+				"^visits/[^\\/]*$",
+				"^care-recipients/[^\\/]*/something-else$",
+			},
+		)
+	})
+}

--- a/postgres/store.go
+++ b/postgres/store.go
@@ -141,8 +141,8 @@ func (s *Storage) MatchingStream(ctx context.Context, matcher events.Matcher) ch
 	channel := make(chan cloudevents.Event)
 
 	go func() {
-		streamAsRegex := "^" + strings.ReplaceAll(matcher.UriTemplate, "*", "[^\\/]*") + "$"
-		rows, err := s.conn.QueryEx(ctx, "select number, stream, sequence_number_in_stream, event from events where number > $1 and stream ~ $2 order by number asc", nil, matcher.LastEventNumber, streamAsRegex)
+		query, args := buildSelectQuery(matcher)
+		rows, err := s.conn.QueryEx(ctx, query, nil, args...)
 		if err != nil {
 			fmt.Println("error went loading historical events", err)
 			close(channel)

--- a/store/event_stream_test.go
+++ b/store/event_stream_test.go
@@ -25,7 +25,7 @@ func TestEventStream(t *testing.T) {
 		ctx, stop := context.WithCancel(context.Background())
 
 		channel := factory.NewEventStream(ctx, events.Matcher{
-			UriTemplate: "a-stream",
+			UriTemplates: []string{"a-stream"},
 		})
 
 		events.ExpectEventWithId(t, <-channel, "1234")
@@ -42,7 +42,7 @@ func TestEventStream(t *testing.T) {
 		defer stop()
 
 		channel := factory.NewEventStream(ctx, events.Matcher{
-			UriTemplate: "visits/*",
+			UriTemplates: []string{"visits/{id}"},
 		})
 
 		go func() {
@@ -74,7 +74,7 @@ func TestEventStream(t *testing.T) {
 		}
 
 		channel := factory.NewEventStream(ctx, events.Matcher{
-			UriTemplate: "visits/*",
+			UriTemplates: []string{"visits/{id}"},
 		})
 
 		go func() {
@@ -104,7 +104,7 @@ func TestEventStream(t *testing.T) {
 		}
 
 		channel := factory.NewEventStream(ctx, events.Matcher{
-			UriTemplate: "visits/*",
+			UriTemplates: []string{"visits/{id}"},
 		})
 
 		go func() {

--- a/store/named_consumers.go
+++ b/store/named_consumers.go
@@ -45,7 +45,7 @@ func NewNamedConsumers(sseRouter *SSERouter, store EventStore, loader EventLoade
 }
 
 func (cg *NamedConsumers) Mount(router *chi.Mux) {
-	router.Get("/consumer/{name}/stream", cg.Stream)
+	router.Get("/consumer/{name}/sse", cg.Stream)
 	router.Put("/consumer/{name}/commit", cg.CommitOffset)
 }
 
@@ -77,7 +77,7 @@ func (cg *NamedConsumers) Stream(rw http.ResponseWriter, req *http.Request) {
 
 	offset := getLastEvent(
 		cg.loader.MatchingStream(req.Context(), events.Matcher{
-			UriTemplate: commitOffsetStreamFromConsumerName(consumerName),
+			UriTemplates: []string{commitOffsetStreamFromConsumerName(consumerName)},
 		}),
 	)
 

--- a/store/named_consumers_test.go
+++ b/store/named_consumers_test.go
@@ -95,7 +95,7 @@ func TestNamedConsumers(t *testing.T) {
 			ExpectResponseCode(t, response, 200)
 
 			committedEvent := <-storage.MatchingStream(context.Background(), events.Matcher{
-				UriTemplate: fmt.Sprintf("fossil/consumer/%s/commit-offsets", consumerName),
+				UriTemplates: []string{fmt.Sprintf("fossil/consumer/%s/commit-offsets", consumerName)},
 			})
 
 			offset, err := getCommittedOffsetFromEvent(&committedEvent)

--- a/store/sse.go
+++ b/store/sse.go
@@ -23,10 +23,10 @@ func NewSSERouter(eventStreamFactory *EventStreamFactory, store EventStore) *SSE
 
 func matcherFromRequest(store EventStore, req *http.Request) (events.Matcher, error) {
 	matcher := events.Matcher{}
-	matcher.UriTemplate = req.URL.Query().Get("matcher")
+	matcher.UriTemplates = req.URL.Query()["stream"]
 
-	if matcher.UriTemplate == "" {
-		return matcher, errors.New("no matcher found in URL")
+	if len(matcher.UriTemplates) == 0 {
+		return matcher, errors.New("no 'stream' template found in URL")
 	}
 
 	lastEventNumber := req.Header.Get("Last-Fossil-Event-Number")
@@ -56,7 +56,7 @@ func matcherFromRequest(store EventStore, req *http.Request) (events.Matcher, er
 }
 
 func (r *SSERouter) Mount(router *chi.Mux) {
-	router.Get("/stream", r.StreamEvents)
+	router.Get("/sse", r.StreamEvents)
 }
 
 func (r *SSERouter) StreamEvents(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This is in line with our values of re-use existing standards as much as possible.